### PR TITLE
refactor: removed default R state

### DIFF
--- a/ritm_core/src/turing_graph.rs
+++ b/ritm_core/src/turing_graph.rs
@@ -52,7 +52,6 @@ impl TuringMachineGraph {
     /// Three default states will be created :
     /// * `q_i` : The initial state
     /// * `q_a` : The default accepting state
-    /// * `q_r` : The default rejecting state
     pub fn new(k: usize) -> Result<Self, TuringGraphError> {
         if k == 0 {
             return Err(TuringGraphError::NotEnoughTapesError);
@@ -60,17 +59,15 @@ impl TuringMachineGraph {
         // Add the default states
         let init_state = TuringState::new(TuringStateType::Normal, "i");
         let accepting_state = TuringState::new(TuringStateType::Accepting, "a");
-        let rejecting_state = TuringState::new(TuringStateType::Rejecting, "r");
 
         // Create the hash map with the already known states
         let mut name_index_hashmap: HashMap<String, usize> = HashMap::new();
         name_index_hashmap.insert("i".to_string(), 0); // init
         name_index_hashmap.insert("a".to_string(), 1); // accepting
-        name_index_hashmap.insert("r".to_string(), 2); // rejecting
 
         Ok(Self {
             name_index_hashmap,
-            states: vec![init_state, accepting_state, rejecting_state],
+            states: vec![init_state, accepting_state],
             k,
         })
     }
@@ -404,7 +401,7 @@ impl TuringMachineGraph {
     /// Removes a state and **all** mentions of it in **all** transitions of **all** the other states of the TuringMachine using its index.
     fn remove_state_with_index(&mut self, state_index: usize) -> Result<(), TuringGraphError> {
         // if the node is one of the 3 initial nodes, throw an error
-        if state_index <= 2 {
+        if state_index <= 1 {
             return Err(TuringGraphError::ImmutableStateError {
                 state: self
                     .get_state(state_index)

--- a/ritm_core/tests/turing_graph_test.rs
+++ b/ritm_core/tests/turing_graph_test.rs
@@ -10,7 +10,6 @@ fn create_graph_test() {
 
     assert_eq!(*graph.get_name_index_hashmap().get("i").unwrap(), 0);
     assert_eq!(*graph.get_name_index_hashmap().get("a").unwrap(), 1);
-    assert_eq!(*graph.get_name_index_hashmap().get("r").unwrap(), 2);
 
     assert!(matches!(
         TuringMachineGraph::new(0),
@@ -20,10 +19,6 @@ fn create_graph_test() {
     assert_eq!(
         TuringStateType::Accepting,
         graph.get_state_from_name("a").unwrap().state_type
-    );
-    assert_eq!(
-        TuringStateType::Rejecting,
-        graph.get_state_from_name("r").unwrap().state_type
     );
     assert_eq!(
         TuringStateType::Normal,
@@ -46,11 +41,6 @@ fn delete_init_nodes_test() {
         graph.remove_state_with_name("a"),
         Err(TuringGraphError::ImmutableStateError { state: _ })
     ));
-
-    assert!(matches!(
-        graph.remove_state_with_name("r"),
-        Err(TuringGraphError::ImmutableStateError { state: _ })
-    ));
 }
 
 #[test]
@@ -60,30 +50,29 @@ fn add_nodes() {
     // Check they already exists
     assert_eq!(graph.add_state("i"), 0);
     assert_eq!(graph.add_state("a"), 1);
-    assert_eq!(graph.add_state("r"), 2);
 
     // Add new ones
-    assert_eq!(graph.add_state("b"), 3);
-    assert_eq!(graph.add_state("c"), 4);
-    assert_eq!(graph.add_state("d"), 5);
+    assert_eq!(graph.add_state("b"), 2);
+    assert_eq!(graph.add_state("c"), 3);
+    assert_eq!(graph.add_state("d"), 4);
     // Check they got the correct index
-    assert_eq!(graph.add_state("b"), 3);
-    assert_eq!(graph.add_state("c"), 4);
-    assert_eq!(graph.add_state("d"), 5);
+    assert_eq!(graph.add_state("b"), 2);
+    assert_eq!(graph.add_state("c"), 3);
+    assert_eq!(graph.add_state("d"), 4);
 }
 
 #[test]
 fn get_nodes_test() {
     let mut graph = TuringMachineGraph::new(1).unwrap();
     // Add new nodes
-    assert_eq!(graph.add_state("b"), 3);
-    assert_eq!(graph.add_state("c"), 4);
-    assert_eq!(graph.add_state("d"), 5);
+    assert_eq!(graph.add_state("b"), 2);
+    assert_eq!(graph.add_state("c"), 3);
+    assert_eq!(graph.add_state("d"), 4);
 
     // check they get be obtained
-    assert_eq!(graph.get_state(3).unwrap().name.clone(), "b");
-    assert_eq!(graph.get_state(4).unwrap().name.clone(), "c");
-    assert_eq!(graph.get_state(5).unwrap().name.clone(), "d");
+    assert_eq!(graph.get_state(2).unwrap().name.clone(), "b");
+    assert_eq!(graph.get_state(3).unwrap().name.clone(), "c");
+    assert_eq!(graph.get_state(4).unwrap().name.clone(), "d");
 
     // check they get be obtained
     assert_eq!(graph.get_state_from_name("b").unwrap().name.clone(), "b");
@@ -327,8 +316,11 @@ fn delete_node() {
         .append_rule_state_by_name("t", t1.clone(), "a")
         .unwrap(); // t -> a
     graph
-        .append_rule_state_by_name("r", t2.clone(), "t")
-        .unwrap(); // r -> t
+        .append_rule_state_by_name("a", t2.clone(), "t")
+        .unwrap(); // a -> t
+    graph
+        .append_rule_state_by_name("p", t2.clone(), "t")
+        .unwrap(); // a -> t
     graph
         .append_rule_state_by_name("q", t3.clone(), "t")
         .unwrap(); // q -> t
@@ -357,7 +349,7 @@ fn delete_node() {
     // Check all the related transitions to 't' are also gone
     assert!(
         graph
-            .get_state_from_name("r")
+            .get_state_from_name("p")
             .unwrap()
             .get_valid_transitions(&vec!('ç', 'ç'))
             .is_empty()

--- a/ritm_repl/README.md
+++ b/ritm_repl/README.md
@@ -46,10 +46,10 @@ Creating a blank graph is as easy as specifying the number of working tapes that
 This is because every transitions will have to respect this value when you will add them later.
 
 > [!NOTE]
-> A blank graph consists of three default states :
+> A blank graph consists of two default states :
 > * $q_i$ : The **initial** state where every execution will start from.
 > * $q_a$ : The **accepting** state where an execution should end to *accept* an input.
-> * $q_r$ : The **rejecting** state. This state can be use to directly *reject* an input.
+<!-- > * $q_r$ : The **rejecting** state. This state can be use to directly *reject* an input. -->
 
 ### Load
 


### PR DESCRIPTION
* Removed the default reject state called `R` since it was never used and was shown to be confusing to users.